### PR TITLE
fixed test - macOS 10.12.5, Perl 6.c, Rakudo version 2017.04.3

### DIFF
--- a/examples/play-sine-callback
+++ b/examples/play-sine-callback
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+use NativeCall;
+use lib 'lib';
+use Audio::Portaudio;
+
+sub callback(CArray $inputbuf, CArray $outputbuf, int32 $framecount, Audio::PortAudio::StreamCallbackTimeInfo $callback-time-info, int32 $cb-flags, CArray $cb-user-data) returns int32 {
+
+  # fails with: MoarVM panic: Internal error: Unwound entire stack and missed handler
+  #$outputbuf[0] = 0.0e0;
+
+  # this works for a while and then: terminated by signal SIGSEGV (Address boundary error)
+  my $samples = nativecast(CArray[num32], $outputbuf);
+  $samples[$_] = 0.0e0 for ^$framecount;
+  $samples[0] = 1.0e0;
+
+  return 0;
+}
+
+multi sub MAIN() {
+	my $pa = Audio::PortAudio.new;
+	my $st = $pa.open-default-stream-with-callback(0, 1, Audio::PortAudio::Float32, 44100, 256, &callback);
+	$st.start;
+  loop { sleep 1 }
+}

--- a/lib/Audio/PortAudio.pm
+++ b/lib/Audio/PortAudio.pm
@@ -990,6 +990,16 @@ class Audio::PortAudio {
         }
         $stream[0];
     }
+
+    method open-default-stream-with-callback(Int $input = 0, Int $output = 2, StreamFormat $format = StreamFormat::Float32, Int $sample-rate = 44100, Int $frames-per-buffer = 256, &callback () = Code) returns Stream {
+        my CArray[Stream] $stream = CArray[Stream].new;
+        $stream[0] = Stream.new;
+        my $rc = Pa_OpenDefaultStream($stream,$input,$output,$format.Int, Num($sample-rate), $frames-per-buffer, &callback, CArray);
+        if $rc != 0 {
+            X::OpenError.new(code => $rc, error-text => self.error-text($rc)).throw;
+        }
+        $stream[0];
+    }
     
     sub Pa_OpenStream(CArray[Stream] $stream,
                       StreamParameters $in-params,

--- a/t/020-basic.t
+++ b/t/020-basic.t
@@ -37,7 +37,7 @@ if library-exists('portaudio', v2) {
         ok $stream.active, "and it is active now";
         is $stream.info.sample-rate, 44100e0, "got some info";
         nok $stream.stopped, "and it is obviously not stopped anymore";
-        ok $stream.write-available, "and write-available gives us something";
+        cmp-ok $stream.write-available, '<=', 0, "and write-available gives us something non-negative";
 
         diag "may make a quick blip";
         use NativeCall;


### PR DESCRIPTION
Hi :)

`zef install Audio::PortAudio` fails for me on the `write-available` test. As far as I can tell, 0 is valid return value for `Pa_GetStreamWriteAvailable`. Only negative values represent errors. Here's some c++ that shows what I mean.

```c++
#include <cassert>
#include <cstdio>
#include "portaudio.h"

int p(const void *input, void *output, unsigned long frameCount,
      const PaStreamCallbackTimeInfo *timeInfo,
      PaStreamCallbackFlags statusFlags, void *userData) {
  return 0;
}

int main(int argc, char *argv[]) {
  {
    PaError err;
    err = Pa_Initialize();
    assert(err == paNoError);

    PaStream *s;

    // GetStreamWriteAvailable === SUCCESS
    //
    err =
        Pa_OpenDefaultStream(&s, 0, 2, paFloat32, 44100, 512, nullptr, nullptr);

    assert(err == paNoError);

    printf("ACTIVE: %d\n", Pa_IsStreamActive(s));
    printf("STOPPED: %d\n", Pa_IsStreamStopped(s));

    err = Pa_StartStream(s);
    assert(err == paNoError);

    printf("ACTIVE: %d\n", Pa_IsStreamActive(s));
    printf("STOPPED: %d\n", Pa_IsStreamStopped(s));

    err = Pa_GetStreamWriteAvailable(s);
    printf("ERROR: %s\n", Pa_GetErrorText(err));

    printf("VALUE: %d\n", err);
  }

  {
    PaError err;
    err = Pa_Initialize();
    assert(err == paNoError);

    PaStream *s;

    // GetStreamWriteAvailable === FAILURE
    err = Pa_OpenDefaultStream(&s, 0, 2, paFloat32, 44100, 512, p, nullptr);

    assert(err == paNoError);

    printf("ACTIVE: %d\n", Pa_IsStreamActive(s));
    printf("STOPPED: %d\n", Pa_IsStreamStopped(s));

    err = Pa_StartStream(s);
    assert(err == paNoError);

    printf("ACTIVE: %d\n", Pa_IsStreamActive(s));
    printf("STOPPED: %d\n", Pa_IsStreamStopped(s));

    err = Pa_GetStreamWriteAvailable(s);
    printf("ERROR: %s\n", Pa_GetErrorText(err));
  }
}
```

> ACTIVE: 0
> STOPPED: 1
> ACTIVE: 1
> STOPPED: 0
> ERROR: Success
> VALUE: 0
> ACTIVE: 0
> STOPPED: 1
> ACTIVE: 1
> STOPPED: 0
> ERROR: Can't write to a callback stream

It also shows that if/when you implement the callback interface, you'll have to use a different test, but I guess that's obvious.

I want a callback-based interface. That's why I forked your repo and dug into the code. Have you given any more thought on how to implement it in a perl6 way?
