### PR TITLE
Explicit conversion of int32 to Bool doesn't work, use so instead

### DIFF
--- a/lib/Audio/PortAudio.rakumod
+++ b/lib/Audio/PortAudio.rakumod
@@ -825,13 +825,13 @@ class Audio::PortAudio {
         sub Pa_IsStreamStopped(Stream $stream --> int32 )  is native('portaudio', v2) { * }
 
         method stopped( --> Bool )  {
-            Bool(Pa_IsStreamStopped(self));
+            so Pa_IsStreamStopped(self);
         }
 
         sub Pa_IsStreamActive(Stream $stream --> int32 )  is native('portaudio', v2) { * }
 
         method active( --> Bool )  {
-            Bool(Pa_IsStreamActive(self));
+            so Pa_IsStreamActive(self);
         }
 
         sub Pa_GetStreamReadAvailable( Stream $stream --> int32 )  is native('portaudio', v2) { * }


### PR DESCRIPTION
Calling `Bool(int32)` does not seem to work anymore. Instead use `so` to produce the same effective result.

This fixes tests such that the package installs without issue again.